### PR TITLE
Redirect home on empty query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ server
 
 # generated mock files
 mock_*.go
+coverage.txt
 
 # node modules
 node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ server
 
 # generated mock files
 mock_*.go
-coverage.txt
 
 # node modules
 node_modules

--- a/pkg/view/recipe/search.go
+++ b/pkg/view/recipe/search.go
@@ -1,11 +1,12 @@
 package recipe
 
 import (
-	"github.com/NoUmlautsAllowed/gocook/pkg/api"
-	"github.com/gin-gonic/gin"
 	"math"
 	"net/http"
 	"strconv"
+
+	"github.com/NoUmlautsAllowed/gocook/pkg/api"
+	"github.com/gin-gonic/gin"
 )
 
 type tmplPageData struct {
@@ -122,11 +123,13 @@ func (t *TemplateViewer) ShowSearchResults(c *gin.Context) {
 		}
 		c.HTML(http.StatusOK, t.searchResultsTemplate, tmplData)
 
-	} else {
+	} else if err != nil {
 		c.JSON(http.StatusBadRequest, gin.Error{
 			Err:  err,
-			Type: 0,
+			Type: gin.ErrorTypeBind,
 			Meta: nil,
 		})
+	} else {
+		c.Redirect(http.StatusMovedPermanently, "/")
 	}
 }

--- a/pkg/view/recipe/search_test.go
+++ b/pkg/view/recipe/search_test.go
@@ -75,7 +75,7 @@ func TestTemplateViewer_ShowSearchResults_InternalError(t *testing.T) {
 	}
 }
 
-func TestTemplateViewer_ShowSearchResults_BadRequest(t *testing.T) {
+func TestTemplateViewer_ShowSearchResults_EmptyQuery(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	m := api.NewMockRecipeApi(ctrl)
@@ -100,8 +100,8 @@ func TestTemplateViewer_ShowSearchResults_BadRequest(t *testing.T) {
 
 	r.ServeHTTP(&w, &req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Error("expected status 400")
+	if w.Code != http.StatusMovedPermanently {
+		t.Error("expected status 301")
 	}
 }
 

--- a/templates/search.tmpl
+++ b/templates/search.tmpl
@@ -1,3 +1,3 @@
 <form action="/recipe" method="get">
-    <input name="query" class="input" type="text" placeholder="Rezept..." value="{{ .Query }}">
+    <input name="query" class="input" type="text" placeholder="Rezept..." required value="{{ .Query }}">
 </form>


### PR DESCRIPTION
I don't think it's good UX if an empty search gives you an error, so this changes it to redirect you to the home/search screen if you request an empty query.