### PR TITLE
Fix column count and hide images if not available

### DIFF
--- a/pkg/view/recipe/search.go
+++ b/pkg/view/recipe/search.go
@@ -19,7 +19,6 @@ type tmplSearch struct {
 	api.Search
 	api.RecipeSearch
 	ResultsPerPage int
-	ResultsPerRow  int
 
 	PreviousButOne tmplPageData
 	Previous       tmplPageData
@@ -30,10 +29,7 @@ type tmplSearch struct {
 	Last           tmplPageData
 }
 
-const (
-	defaultResultsPerPage int = 12
-	defaultResultsPerRow  int = 3
-)
+const defaultResultsPerPage int = 15
 
 func (t *TemplateViewer) ShowSearchResults(c *gin.Context) {
 	var search api.Search
@@ -94,7 +90,6 @@ func (t *TemplateViewer) ShowSearchResults(c *gin.Context) {
 			Search:         search,
 			RecipeSearch:   *recipeSearch,
 			ResultsPerPage: defaultResultsPerPage,
-			ResultsPerRow:  defaultResultsPerRow,
 			PreviousButOne: tmplPageData{
 				Offset: previousOffset - defaultResultsPerPage,
 				Page:   (previousOffset-defaultResultsPerPage)/defaultResultsPerPage + 1,

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -7,7 +7,7 @@
 <body>
 
 
-<section class="hero is-chef is-fullheight">
+<main class="hero is-chef is-fullheight">
     <div class="hero-head">
         <div class="mt-6">{{ template  "header.tmpl" }}</div>
     </div>
@@ -23,7 +23,7 @@
             {{ template "footer.tmpl" }}
         </div>
     </div>
-</section>
+</main>
 
 </body>
 </html>

--- a/templates/recipe.tmpl
+++ b/templates/recipe.tmpl
@@ -5,24 +5,26 @@
     {{ template "head.tmpl" }}
 </head>
 <body>
-<section class="section p-0 hero is-chef">
+<header class="section p-0 hero is-chef">
     <div class="hero-head pb-3 pt-5">
         {{ template "header.tmpl" }}
     </div>
     <div class="hero-body pt-3">
         {{ template "search.tmpl" . }}
     </div>
-</section>
-<section class="section">
+</header>
+<main class="section">
     <div class="fixed-grid">
         <div class="grid">
             <div class="cell is-col-span-2-mobile">
                 <div class="box">
                     <div class="content">
                     <h1>{{ .Title }}</h1>
+                    {{ if .HasImage }}
                     <figure class="image is-4by5">
                         <img src="{{ .PreviewImageURLTemplate }}" alt="Preview">
                     </figure>
+                    {{ end }}
                     </div>
                 </div>
             </div>
@@ -52,11 +54,11 @@
             {{ end }}
         </div>
     </div>
-</section>
-<section class="section hero is-chef">
+</main>
+<footer class="section hero is-chef">
     <div class="hero-foot">
         {{ template "footer.tmpl" }}
     </div>
-</section>
+</footer>
 </body>
 </html>

--- a/templates/results.tmpl
+++ b/templates/results.tmpl
@@ -5,48 +5,48 @@
     {{ template "head.tmpl"}}
 </head>
 <body>
-<section class="section p-0 hero is-chef">
+<header class="section p-0 hero is-chef">
     <div class="hero-head pb-3 pt-5">
         {{ template "header.tmpl" }}
     </div>
     <div class="hero-body pt-3">
         {{ template "search.tmpl" . }}
     </div>
-</section>
-<section class="section">
-<!--    <div class="fixed-grid has-auto-count">-->
-        <div class="grid">
-            {{ range .Results }}
-            <div class="cell is-col-span-2">
-                <div class="p-3 m-3">
-                    <a class="box" href="/recipes/{{ .Recipe.ID }}">
-                        <figure class="image" style="width: 100%">
-                            <img src="{{ .Recipe.PreviewImageURLTemplate }}" alt="Preview">
-                        </figure>
-                        <div class="content pt-3">
-                            <h3>
-                                {{ .Recipe.Title }}
-                            </h3>
-                            <p>{{ .Recipe.Subtitle }}</p>
-                            <br>
-                            {{ template "recipeinfo.tmpl" .Recipe }}
-                        </div>
-                    </a>
+</header>
+<main class="section">
+        <div class="fixed-grid has-4-cols-widescreen has-3-cols-tablet has-1-cols-mobile">
+            <div class="grid">
+                {{ range .Results }}
+                <div class="cell">
+                    <div class="p-3 m-3">
+                        <a class="box" href="/recipes/{{ .Recipe.ID }}">
+                            <figure class="image" style="width: 100%">
+                                <img src="{{ .Recipe.PreviewImageURLTemplate }}" alt="Preview">
+                            </figure>
+                            <div class="content pt-3">
+                                <h3>
+                                    {{ .Recipe.Title }}
+                                </h3>
+                                <p>{{ .Recipe.Subtitle }}</p>
+                                <br>
+                                {{ template "recipeinfo.tmpl" .Recipe }}
+                            </div>
+                        </a>
+                    </div>
                 </div>
+                {{ end }}
             </div>
-            {{ end }}
         </div>
-<!--    </div>-->
     <div class="container">
         <div class="p-3">
             {{ template "pagination.tmpl" . }}
         </div>
     </div>
-</section>
-<section class="section hero is-chef">
+</main>
+<footer class="section hero is-chef">
     <div class="hero-foot">
         {{ template "footer.tmpl" }}
     </div>
-</section>
+</footer>
 </body>
 </html>

--- a/templates/results.tmpl
+++ b/templates/results.tmpl
@@ -14,7 +14,7 @@
     </div>
 </header>
 <main class="section">
-        <div class="fixed-grid has-4-cols-widescreen has-3-cols-tablet has-1-cols-mobile">
+        <div class="fixed-grid has-5-cols-widescreen has-3-cols-tablet has-1-cols-mobile">
             <div class="grid">
                 {{ range .Results }}
                 <div class="cell">

--- a/templates/results.tmpl
+++ b/templates/results.tmpl
@@ -20,9 +20,11 @@
                 <div class="cell">
                     <div class="p-3 m-3">
                         <a class="box" href="/recipes/{{ .Recipe.ID }}">
+                            {{ if .Recipe.HasImage }}
                             <figure class="image" style="width: 100%">
                                 <img src="{{ .Recipe.PreviewImageURLTemplate }}" alt="Preview">
                             </figure>
+                            {{ end }}
                             <div class="content pt-3">
                                 <h3>
                                     {{ .Recipe.Title }}


### PR DESCRIPTION
- Fix the column count to 4 on desktop, 3 on tablet and 1 on mobile. (You used 5 before which looks ugly because there are 12 results and 12/5 is not an integer -> the last row isn't filled completely.) You can try why this is necessary by searching for a very specific term that only returns exactly one result.
- If there's no image available, just hide the `img` tag.
- Use correct HTML landmarks instead of just `section`.